### PR TITLE
Bump dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1308,9 +1308,9 @@
 			}
 		},
 		"node_modules/discord-api-types": {
-			"version": "0.37.102",
-			"resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.102.tgz",
-			"integrity": "sha512-5+m5twqG8n77rLhKuh2c/971UWszEL/c3KbdvVLUBTPXuS8PbYC/7W7NYhwP02qowjj6CHoKYZbD0ppOUCsT6g==",
+			"version": "0.37.103",
+			"resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.103.tgz",
+			"integrity": "sha512-r+qitxXKe2l6KFw5odPdZSSqdEou+7eNC7BfbZ7mny5Me/K06wCTeKUMVeH/YsI9+4QQudskeQ307kr/7ppQ1A==",
 			"dev": true
 		},
 		"node_modules/discord.js": {


### PR DESCRIPTION
<details><summary>Changed dependencies</summary>

- Bumped [`discord-api-types@0.37.102`](https://npmjs.com/package/discord-api-types/v/0.37.102) to [`0.37.103`](https://npmjs.com/package/discord-api-types/v/0.37.103) ([see recent commits](https://github.com/discordjs/discord-api-types))
</details><details><summary>Requirement changes</summary>

*No requirements changed.*
</details>
