### PR TITLE
Bump dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -59,9 +59,9 @@
 			}
 		},
 		"node_modules/@discordjs/formatters": {
-			"version": "0.6.0-dev.1729383195-6cbe2487b",
-			"resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.6.0-dev.1729383195-6cbe2487b.tgz",
-			"integrity": "sha512-t0N6gxIntdAkpqh2oUXEn6w0LHa/roHAuw7Rp7VjmmuXyBd2obUMm36zNsBa6Ms85PrRX+vQFSDnCsxBGFoerQ==",
+			"version": "0.6.0-dev.1729857898-b932b64d9",
+			"resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.6.0-dev.1729857898-b932b64d9.tgz",
+			"integrity": "sha512-Z7LqwNossaVP5IuTrFd/r+56CnzC81Hn+i4CKYtHqaM3foNTTDi9fyvZ/DxX3fWbSTT83B9yjqXcrdB5Eclo9g==",
 			"dev": true,
 			"dependencies": {
 				"discord-api-types": "^0.37.101"
@@ -74,9 +74,9 @@
 			}
 		},
 		"node_modules/@discordjs/rest": {
-			"version": "2.4.1-dev.1729383193-6cbe2487b",
-			"resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.4.1-dev.1729383193-6cbe2487b.tgz",
-			"integrity": "sha512-s0/toesIrtjHtWj9g8oyIDHunJ6WZKAtDv//2+3qn39j/qH9RbHrP89qz+v0Ar6fYvZppQfzniSAJ/9AgfF5fg==",
+			"version": "2.4.1-dev.1729857900-b932b64d9",
+			"resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.4.1-dev.1729857900-b932b64d9.tgz",
+			"integrity": "sha512-76qiAzNEcIXWKX45Kj/SfwLElvlPc/u77hRXsjgxPiArHUVVgn3Z1rII4xH2BDtvF5EdFxVgbiCos7c27ks8MA==",
 			"dev": true,
 			"dependencies": {
 				"@discordjs/collection": "^2.1.1",
@@ -97,9 +97,9 @@
 			}
 		},
 		"node_modules/@discordjs/util": {
-			"version": "1.1.2-dev.1729383186-6cbe2487b",
-			"resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.1.2-dev.1729383186-6cbe2487b.tgz",
-			"integrity": "sha512-NAf2LFOXv2Waz/dUoN/ns4rElcFJ7oyMwT5l5KSzBBPylz8+4zULyJOqNTf8DeeHg4i+avNGR/8USUxQERUQzg==",
+			"version": "1.1.2-dev.1729857890-b932b64d9",
+			"resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.1.2-dev.1729857890-b932b64d9.tgz",
+			"integrity": "sha512-Ta+qJYpajvfOi9hXki0kO3gBmHKC70pUcuTJy2xxIm31zq9EX5Jqo60HJLCw+h0QqL5RBxyG+8BEvQ5s6D0GAQ==",
 			"dev": true,
 			"engines": {
 				"node": ">=18"


### PR DESCRIPTION
<details><summary>Changed dependencies</summary>

- Bumped [`@discordjs/formatters@0.6.0-dev.1729383195-6cbe2487b`](https://npmjs.com/package/@discordjs/formatters/v/0.6.0-dev.1729383195-6cbe2487b) to [`0.6.0-dev.1729857898-b932b64d9`](https://npmjs.com/package/@discordjs/formatters/v/0.6.0-dev.1729857898-b932b64d9) ([see recent commits](https://github.com/discordjs/discord.js/commits/HEAD/packages/formatters))
- Bumped [`@discordjs/rest@2.4.1-dev.1729383193-6cbe2487b`](https://npmjs.com/package/@discordjs/rest/v/2.4.1-dev.1729383193-6cbe2487b) to [`2.4.1-dev.1729857900-b932b64d9`](https://npmjs.com/package/@discordjs/rest/v/2.4.1-dev.1729857900-b932b64d9) ([see recent commits](https://github.com/discordjs/discord.js/commits/HEAD/packages/rest))
- Bumped [`@discordjs/util@1.1.2-dev.1729383186-6cbe2487b`](https://npmjs.com/package/@discordjs/util/v/1.1.2-dev.1729383186-6cbe2487b) to [`1.1.2-dev.1729857890-b932b64d9`](https://npmjs.com/package/@discordjs/util/v/1.1.2-dev.1729857890-b932b64d9) ([see recent commits](https://github.com/discordjs/discord.js/commits/HEAD/packages/util))
</details><details><summary>Requirement changes</summary>

*No requirements changed.*
</details>
