### PR TITLE
Bump dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -59,12 +59,12 @@
 			}
 		},
 		"node_modules/@discordjs/formatters": {
-			"version": "0.6.0-dev.1729857898-b932b64d9",
-			"resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.6.0-dev.1729857898-b932b64d9.tgz",
-			"integrity": "sha512-Z7LqwNossaVP5IuTrFd/r+56CnzC81Hn+i4CKYtHqaM3foNTTDi9fyvZ/DxX3fWbSTT83B9yjqXcrdB5Eclo9g==",
+			"version": "0.6.0-dev.1730030720-ed78e4570",
+			"resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.6.0-dev.1730030720-ed78e4570.tgz",
+			"integrity": "sha512-Pt4vVi2N7jGawPY95/u8Rl123X2FBGvZkQGEYPUtXvvmEhMrrmAXjiAxLVg78PZh7ZCtC4mZ8ihyRpxhiA0i7A==",
 			"dev": true,
 			"dependencies": {
-				"discord-api-types": "^0.37.101"
+				"discord-api-types": "^0.37.103"
 			},
 			"engines": {
 				"node": ">=18"
@@ -74,9 +74,9 @@
 			}
 		},
 		"node_modules/@discordjs/rest": {
-			"version": "2.4.1-dev.1729857900-b932b64d9",
-			"resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.4.1-dev.1729857900-b932b64d9.tgz",
-			"integrity": "sha512-76qiAzNEcIXWKX45Kj/SfwLElvlPc/u77hRXsjgxPiArHUVVgn3Z1rII4xH2BDtvF5EdFxVgbiCos7c27ks8MA==",
+			"version": "2.4.1-dev.1730030709-ed78e4570",
+			"resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.4.1-dev.1730030709-ed78e4570.tgz",
+			"integrity": "sha512-pdktWn2YArBW4NSpdi3k+WThROGHl1FePlepnFQRhmDiZ3SuO8BoQySIDMBwcVdepFhhL6u5OReq9MrEDyP9RQ==",
 			"dev": true,
 			"dependencies": {
 				"@discordjs/collection": "^2.1.1",
@@ -84,7 +84,7 @@
 				"@sapphire/async-queue": "^1.5.3",
 				"@sapphire/snowflake": "^3.5.3",
 				"@vladfrangu/async_event_emitter": "^2.4.6",
-				"discord-api-types": "^0.37.101",
+				"discord-api-types": "^0.37.103",
 				"magic-bytes.js": "^1.10.0",
 				"tslib": "^2.6.3",
 				"undici": "6.19.8"
@@ -97,9 +97,9 @@
 			}
 		},
 		"node_modules/@discordjs/util": {
-			"version": "1.1.2-dev.1729857890-b932b64d9",
-			"resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.1.2-dev.1729857890-b932b64d9.tgz",
-			"integrity": "sha512-Ta+qJYpajvfOi9hXki0kO3gBmHKC70pUcuTJy2xxIm31zq9EX5Jqo60HJLCw+h0QqL5RBxyG+8BEvQ5s6D0GAQ==",
+			"version": "1.1.2-dev.1730030707-ed78e4570",
+			"resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.1.2-dev.1730030707-ed78e4570.tgz",
+			"integrity": "sha512-oE04hQJ3gqSuc9mPwybqiqS5IQwC581QZNZjvQaFUk68349iND2RdVXIqTyr+hFoCPZ6zauGrVylWI/cBGmOYw==",
 			"dev": true,
 			"engines": {
 				"node": ">=18"


### PR DESCRIPTION
<details><summary>Changed dependencies</summary>

- Bumped [`@discordjs/formatters@0.6.0-dev.1729857898-b932b64d9`](https://npmjs.com/package/@discordjs/formatters/v/0.6.0-dev.1729857898-b932b64d9) to [`0.6.0-dev.1730030720-ed78e4570`](https://npmjs.com/package/@discordjs/formatters/v/0.6.0-dev.1730030720-ed78e4570) ([see recent commits](https://github.com/discordjs/discord.js/commits/HEAD/packages/formatters))
- Bumped [`@discordjs/rest@2.4.1-dev.1729857900-b932b64d9`](https://npmjs.com/package/@discordjs/rest/v/2.4.1-dev.1729857900-b932b64d9) to [`2.4.1-dev.1730030709-ed78e4570`](https://npmjs.com/package/@discordjs/rest/v/2.4.1-dev.1730030709-ed78e4570) ([see recent commits](https://github.com/discordjs/discord.js/commits/HEAD/packages/rest))
- Bumped [`@discordjs/util@1.1.2-dev.1729857890-b932b64d9`](https://npmjs.com/package/@discordjs/util/v/1.1.2-dev.1729857890-b932b64d9) to [`1.1.2-dev.1730030707-ed78e4570`](https://npmjs.com/package/@discordjs/util/v/1.1.2-dev.1730030707-ed78e4570) ([see recent commits](https://github.com/discordjs/discord.js/commits/HEAD/packages/util))
</details><details><summary>Requirement changes</summary>

*No requirements changed.*
</details>
