### PR TITLE
Bump dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
 			"integrity": "sha512-CDy8PSqUiargLggQ/eRydWqTOrj1AWkDN+uUYL28/aTexjCnlZ/m4sLMCc7eAECSfBzEB5Qg6xpu68rgKGjjNw==",
 			"deprecated": "This version is deprecated. Please use a newer version.",
 			"dev": true,
+			"license": "Apache-2.0",
 			"dependencies": {
 				"@discordjs/formatters": "^0.5.0",
 				"@discordjs/util": "^1.1.1",
@@ -54,55 +55,80 @@
 			"integrity": "sha512-XBKQBrCzWYIvWHVGNLVlfvbSJtLzBV+bS22xhfG7mpVyfwOfXEZTHPcChEm4RTYy711MzY3MD/6vMyD+lQ7p+A==",
 			"deprecated": "This version is deprecated. Please use a newer version.",
 			"dev": true,
+			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=16.11.0"
 			}
 		},
 		"node_modules/@discordjs/formatters": {
-			"version": "0.6.0-dev.1730030720-ed78e4570",
-			"resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.6.0-dev.1730030720-ed78e4570.tgz",
-			"integrity": "sha512-Pt4vVi2N7jGawPY95/u8Rl123X2FBGvZkQGEYPUtXvvmEhMrrmAXjiAxLVg78PZh7ZCtC4mZ8ihyRpxhiA0i7A==",
+			"version": "1.0.0-dev.1732881914-8efb72e76",
+			"resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-1.0.0-dev.1732881914-8efb72e76.tgz",
+			"integrity": "sha512-wcBsdrLtJi50SHYZ4fFpYIj0r42/WM9u23GBqm5mdPqiAkHW9fYnvAL2rPRpBb8F7+xebtPL7lTGc+TfwWPyWQ==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"dependencies": {
-				"discord-api-types": "^0.37.103"
+				"discord-api-types": "^0.37.109"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=20"
 			},
 			"funding": {
 				"url": "https://github.com/discordjs/discord.js?sponsor"
 			}
 		},
 		"node_modules/@discordjs/rest": {
-			"version": "2.4.1-dev.1730030709-ed78e4570",
-			"resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.4.1-dev.1730030709-ed78e4570.tgz",
-			"integrity": "sha512-pdktWn2YArBW4NSpdi3k+WThROGHl1FePlepnFQRhmDiZ3SuO8BoQySIDMBwcVdepFhhL6u5OReq9MrEDyP9RQ==",
+			"version": "3.0.0-dev.1732881953-8efb72e76",
+			"resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-3.0.0-dev.1732881953-8efb72e76.tgz",
+			"integrity": "sha512-6Fmo/swzXBXctMYIPRnph9GKisLY8URw4rIP5Sj2rLl0agkA5ebBufJeE1wQnc/M9bNhRs8bEpCAcWBR92EEiA==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"dependencies": {
 				"@discordjs/collection": "^2.1.1",
 				"@discordjs/util": "^1.1.1",
-				"@sapphire/async-queue": "^1.5.3",
-				"@sapphire/snowflake": "^3.5.3",
+				"@sapphire/async-queue": "^1.5.5",
+				"@sapphire/snowflake": "^3.5.5",
 				"@vladfrangu/async_event_emitter": "^2.4.6",
-				"discord-api-types": "^0.37.103",
+				"discord-api-types": "^0.37.109",
 				"magic-bytes.js": "^1.10.0",
-				"tslib": "^2.6.3",
-				"undici": "6.19.8"
+				"tslib": "^2.8.1",
+				"undici": "6.21.0"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=20"
 			},
 			"funding": {
 				"url": "https://github.com/discordjs/discord.js?sponsor"
 			}
 		},
-		"node_modules/@discordjs/util": {
-			"version": "1.1.2-dev.1730030707-ed78e4570",
-			"resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.1.2-dev.1730030707-ed78e4570.tgz",
-			"integrity": "sha512-oE04hQJ3gqSuc9mPwybqiqS5IQwC581QZNZjvQaFUk68349iND2RdVXIqTyr+hFoCPZ6zauGrVylWI/cBGmOYw==",
+		"node_modules/@discordjs/rest/node_modules/@sapphire/snowflake": {
+			"version": "3.5.5",
+			"resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.5.tgz",
+			"integrity": "sha512-xzvBr1Q1c4lCe7i6sRnrofxeO1QTP/LKQ6A6qy0iB4x5yfiSfARMEQEghojzTNALDTcv8En04qYNIco9/K9eZQ==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
-				"node": ">=18"
+				"node": ">=v14.0.0",
+				"npm": ">=7.0.0"
+			}
+		},
+		"node_modules/@discordjs/rest/node_modules/undici": {
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-6.21.0.tgz",
+			"integrity": "sha512-BUgJXc752Kou3oOIuU1i+yZZypyZRqNPW0vqoMPl8VaoalSfeR0D8/t4iAS3yirs79SSMTxTag+ZC86uswv+Cw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.17"
+			}
+		},
+		"node_modules/@discordjs/util": {
+			"version": "2.0.0-dev.1732881914-8efb72e76",
+			"resolved": "https://registry.npmjs.org/@discordjs/util/-/util-2.0.0-dev.1732881914-8efb72e76.tgz",
+			"integrity": "sha512-/5qqFRdb9jAu5R3G+b7mMdWTc/l4LakmEwQpFdoWSXSNDOFCEMtn//DpuDf8gxHicnHI2OCTjWmcqWHfjNUTqg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=20"
 			},
 			"funding": {
 				"url": "https://github.com/discordjs/discord.js?sponsor"
@@ -114,6 +140,7 @@
 			"integrity": "sha512-AEck4R1oBztXXoRsVW8mYj8ZLJHSzo1W+erbHmatLk/qHWV3ni2mtCpGWM+j1OePLO4Ab9ii1K5kgW7WfeFgsQ==",
 			"deprecated": "This version is deprecated. Please use a newer version.",
 			"dev": true,
+			"license": "Apache-2.0",
 			"dependencies": {
 				"@discordjs/collection": "^2.1.0",
 				"@discordjs/rest": "^2.3.0",
@@ -136,7 +163,8 @@
 			"version": "0.37.90",
 			"resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.90.tgz",
 			"integrity": "sha512-lpOJSGrqHuXoM4FV/2HtjoaJpCClGFHpRNIdZEW8zPINlsCHNSfIwA2EQ8dxeE6k1QhhTuM9ZlOGVYXoU7FLgA==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@redguy12/prettier-config": {
 			"version": "3.1.1",
@@ -144,6 +172,7 @@
 			"integrity": "sha512-Mf1Qa9B6DK7uemiHLnZ+7PGodIPx7w28GCxI4JaBmPxnGNttzzpqxfZIHZd68avsVRzSJysscBTEzBWpNqTUpQ==",
 			"dev": true,
 			"hasShrinkwrap": true,
+			"license": "MIT",
 			"dependencies": {
 				"@ianvs/prettier-plugin-sort-imports": "4.3.1",
 				"prettier-plugin-ini": "1.3.0",
@@ -1746,10 +1775,11 @@
 			"dev": true
 		},
 		"node_modules/@sapphire/async-queue": {
-			"version": "1.5.3",
-			"resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.3.tgz",
-			"integrity": "sha512-x7zadcfJGxFka1Q3f8gCts1F0xMwCKbZweM85xECGI0hBTeIZJGGCrHgLggihBoprlQ/hBmDR5LKfIPqnmHM3w==",
+			"version": "1.5.5",
+			"resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.5.tgz",
+			"integrity": "sha512-cvGzxbba6sav2zZkH8GPf2oGk9yYoD5qrNWdu9fRehifgnFZJMV+nuy2nON2roRO4yQQ+v7MK/Pktl/HgfsUXg==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=v14.0.0",
 				"npm": ">=7.0.0"
@@ -1760,6 +1790,7 @@
 			"resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-4.0.0.tgz",
 			"integrity": "sha512-d9dUmWVA7MMiKobL3VpLF8P2aeanRTu6ypG2OIaEv/ZHH/SUQ2iHOVyi5wAPjQ+HmnMuL0whK9ez8I/raWbtIg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
 				"lodash": "^4.17.21"
@@ -1773,6 +1804,7 @@
 			"resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.3.tgz",
 			"integrity": "sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=v14.0.0",
 				"npm": ">=7.0.0"
@@ -1782,13 +1814,15 @@
 			"version": "18.11.19",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.19.tgz",
 			"integrity": "sha512-YUgMWAQBWLObABqrvx8qKO1enAvBUdjZOAWQ5grBAkp5LQv45jBvYKZ3oFS9iKRCQyFjqw6iuEa1vmFqtxYLZw==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@types/ws": {
-			"version": "8.5.12",
-			"resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.12.tgz",
-			"integrity": "sha512-3tPRkv1EtkDpzlgyKyI8pGsGZAGPEaXeu0DOj5DI25Ja91bdAYddYHbADRYVrZMRbfW+1l5YwXVDKohDJNQxkQ==",
+			"version": "8.5.13",
+			"resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.13.tgz",
+			"integrity": "sha512-osM/gWBTPKgHV8XkTunnegTRIsvF6owmf5w+JtAfOw472dptdm0dlGv4xCt6GwQRcC2XVOvvRE/0bAoQcL2QkA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@types/node": "*"
 			}
@@ -1798,16 +1832,18 @@
 			"resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.4.6.tgz",
 			"integrity": "sha512-RaI5qZo6D2CVS6sTHFKg1v5Ohq/+Bo2LZ5gzUEwZ/WkHhwtGTCB/sVLw8ijOkAUxasZ+WshN/Rzj4ywsABJ5ZA==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=v14.0.0",
 				"npm": ">=7.0.0"
 			}
 		},
 		"node_modules/discord-api-types": {
-			"version": "0.37.103",
-			"resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.103.tgz",
-			"integrity": "sha512-r+qitxXKe2l6KFw5odPdZSSqdEou+7eNC7BfbZ7mny5Me/K06wCTeKUMVeH/YsI9+4QQudskeQ307kr/7ppQ1A==",
-			"dev": true
+			"version": "0.37.110",
+			"resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.110.tgz",
+			"integrity": "sha512-wVaAJkrSgNRo8nd523qKYPqkClTNHhjKOk/g6265rzHuc7TNS6Ivz06DPW4iZvnhFobbH95hKlgsRf6jcAbtlA==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/discord.js": {
 			"version": "14.17.0-dev.1727784303-b20346f43",
@@ -1815,6 +1851,7 @@
 			"integrity": "sha512-wWkpC+lGssahr3CkfM9adz2agn4vwKkj7Tx4i7v4MLJJtNONzETXfYzJOD+aupaZZChWworRbY20z1TMGP5rlg==",
 			"deprecated": "This version is deprecated. Please use a newer version.",
 			"dev": true,
+			"license": "Apache-2.0",
 			"dependencies": {
 				"@discordjs/builders": "^1.9.0",
 				"@discordjs/collection": "1.5.3",
@@ -1840,31 +1877,36 @@
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
 			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/lodash": {
 			"version": "4.17.21",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
 			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/lodash.snakecase": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
 			"integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/magic-bytes.js": {
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.10.0.tgz",
 			"integrity": "sha512-/k20Lg2q8LE5xiaaSkMXk4sfvI+9EGEykFS4b0CHHGWqDYU0bGUFSwchNOMA56D7TCs9GwVTkqe9als1/ns8UQ==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/prettier": {
 			"version": "3.3.3",
 			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
 			"integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
 			"dev": true,
+			"license": "MIT",
 			"bin": {
 				"prettier": "bin/prettier.cjs"
 			},
@@ -1879,6 +1921,7 @@
 			"version": "11.0.3",
 			"resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-11.0.3.tgz",
 			"integrity": "sha512-2G2y++21dhj2R7iHAdd0FIzjGwuKZld+7Pl/bTU6YIkrC2ZMbVUjm+luj6A6V34Rv9XfKJDKpTWu9W4Gse1D9g==",
+			"license": "MIT",
 			"dependencies": {
 				"type-fest": "^2.12.2"
 			},
@@ -1893,18 +1936,21 @@
 			"version": "6.0.4",
 			"resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.4.tgz",
 			"integrity": "sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/tslib": {
-			"version": "2.8.0",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.0.tgz",
-			"integrity": "sha512-jWVzBLplnCmoaTr13V9dYbiQ99wvZRd0vNWaDRg+aVYRcjDF3nDksxFDE/+fkXnKhpnUUkmx5pK/v8mCtLVqZA==",
-			"dev": true
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true,
+			"license": "0BSD"
 		},
 		"node_modules/type-fest": {
 			"version": "2.19.0",
 			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
 			"integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+			"license": "(MIT OR CC0-1.0)",
 			"engines": {
 				"node": ">=12.20"
 			},
@@ -1917,6 +1963,7 @@
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
 			"integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -1930,6 +1977,7 @@
 			"resolved": "https://registry.npmjs.org/undici/-/undici-6.19.8.tgz",
 			"integrity": "sha512-U8uCCl2x9TK3WANvmBavymRzxbfFYG+tAu+fgx3zxQy3qdagQqBLwJVrdyO1TBfUXvfKveMKJZhpvUYoOjM+4g==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=18.17"
 			}
@@ -1939,6 +1987,7 @@
 			"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
 			"integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=10.0.0"
 			},


### PR DESCRIPTION
<details><summary>Changed dependencies</summary>

- Bumped [`@discordjs/formatters@0.6.0-dev.1730030720-ed78e4570`](https://npmjs.com/package/@discordjs/formatters/v/0.6.0-dev.1730030720-ed78e4570) to [`1.0.0-dev.1732881914-8efb72e76`](https://npmjs.com/package/@discordjs/formatters/v/1.0.0-dev.1732881914-8efb72e76) ([see recent commits](https://github.com/discordjs/discord.js/commits/HEAD/packages/formatters))
- Bumped [`@discordjs/rest@2.4.1-dev.1730030709-ed78e4570`](https://npmjs.com/package/@discordjs/rest/v/2.4.1-dev.1730030709-ed78e4570) to [`3.0.0-dev.1732881953-8efb72e76`](https://npmjs.com/package/@discordjs/rest/v/3.0.0-dev.1732881953-8efb72e76) ([see recent commits](https://github.com/discordjs/discord.js/commits/HEAD/packages/rest))
- Installed [`@sapphire/snowflake@3.5.5`](https://npmjs.com/package/@sapphire/snowflake/v/3.5.5)
- Installed [`undici@6.21.0`](https://npmjs.com/package/undici/v/6.21.0)
- Bumped [`@discordjs/util@1.1.2-dev.1730030707-ed78e4570`](https://npmjs.com/package/@discordjs/util/v/1.1.2-dev.1730030707-ed78e4570) to [`2.0.0-dev.1732881914-8efb72e76`](https://npmjs.com/package/@discordjs/util/v/2.0.0-dev.1732881914-8efb72e76) ([see recent commits](https://github.com/discordjs/discord.js/commits/HEAD/packages/util))
- Bumped [`@sapphire/async-queue@1.5.3`](https://npmjs.com/package/@sapphire/async-queue/v/1.5.3) to [`1.5.5`](https://npmjs.com/package/@sapphire/async-queue/v/1.5.5) ([see recent commits](https://github.com/sapphiredev/utilities/commits/HEAD/packages/async-queue))
- Bumped [`@types/ws@8.5.12`](https://npmjs.com/package/@types/ws/v/8.5.12) to [`8.5.13`](https://npmjs.com/package/@types/ws/v/8.5.13) ([see recent commits](https://github.com/DefinitelyTyped/DefinitelyTyped/commits/HEAD/types/ws))
- Bumped [`discord-api-types@0.37.103`](https://npmjs.com/package/discord-api-types/v/0.37.103) to [`0.37.110`](https://npmjs.com/package/discord-api-types/v/0.37.110) ([see recent commits](https://github.com/discordjs/discord-api-types))
- Bumped [`tslib@2.8.0`](https://npmjs.com/package/tslib/v/2.8.0) to [`2.8.1`](https://npmjs.com/package/tslib/v/2.8.1) ([see recent commits](https://github.com/Microsoft/tslib))
</details><details><summary>Requirement changes</summary>

*No requirements changed.*
</details>
